### PR TITLE
Don't wait on warning when appointment status is changed succesfully

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mbu_dev_shared_components"
-version = "0.4.0"  # Specify the version manually here
+version = "0.4.1"  # Specify the version manually here
 authors = [
   { name="MBU", email="rpa@mbu.aarhus.dk" },
 ]


### PR DESCRIPTION
Change function in change_appointment_status such that it doesn't wait on warning window when status is changed succesfully