### PR TITLE
params as optional, add number of affected rows to result

### DIFF
--- a/mbu_dev_shared_components/utils/db_stored_procedure_executor.py
+++ b/mbu_dev_shared_components/utils/db_stored_procedure_executor.py
@@ -21,7 +21,7 @@ def execute_stored_procedure(connection_string: str, stored_procedure: str, para
 
     Returns:
         Dict[str, Union[bool, str, Any]]: A dictionary containing the success status, an error message (if any),
-                                           and additional data.
+                                           number of affected rows, and additional data.
     """
     result = {
         "success": False,

--- a/mbu_dev_shared_components/utils/db_stored_procedure_executor.py
+++ b/mbu_dev_shared_components/utils/db_stored_procedure_executor.py
@@ -4,19 +4,19 @@ via the pyodbc library. The function connects to the database and executes the s
 procedure with provided parameters, returning the success status and any error messages.
 """
 import json
-from typing import Dict, Any, Union
+from typing import Dict, Any, Union, Tuple
 from dateutil import parser
 import pyodbc
 
 
-def execute_stored_procedure(connection_string: str, stored_procedure: str, params: Dict[str, Any]) -> Dict[str, Union[bool, str, Any]]:
+def execute_stored_procedure(connection_string: str, stored_procedure: str, params: Dict[str, Tuple[type, Any]] | None = None) -> Dict[str, Union[bool, str, Any]]:
     """
     Executes a stored procedure with the given parameters.
 
     Args:
         connection_string (str): The connection string to connect to the database.
         stored_procedure (str): The name of the stored procedure to execute.
-        params (Dict[str, Any]): A dictionary of parameters to pass to the stored procedure.
+        params (Dict[str, Tuple[type, Any]], optional): A dictionary of parameters to pass to the stored procedure.
                                  Each value should be a tuple of (type, actual_value).
 
     Returns:
@@ -39,23 +39,29 @@ def execute_stored_procedure(connection_string: str, stored_procedure: str, para
     try:
         with pyodbc.connect(connection_string) as conn:
             with conn.cursor() as cursor:
-                param_placeholders = ', '.join([f"@{key} = ?" for key in params.keys()])
-                param_values = []
+                if params:
+                    param_placeholders = ', '.join([f"@{key} = ?" for key in params.keys()])
+                    param_values = []
 
-                for key, value in params.items():
-                    if isinstance(value, tuple) and len(value) == 2:
-                        value_type, actual_value = value
-                        if value_type in type_mapping:
-                            param_values.append(type_mapping[value_type](actual_value))
+                    for key, value in params.items():
+                        if isinstance(value, tuple) and len(value) == 2:
+                            value_type, actual_value = value
+                            if value_type in type_mapping:
+                                param_values.append(type_mapping[value_type](actual_value))
+                            else:
+                                param_values.append(actual_value)
                         else:
-                            param_values.append(actual_value)
-                    else:
-                        raise ValueError("Each parameter value must be a tuple of (type, actual_value).")
+                            raise ValueError("Each parameter value must be a tuple of (type, actual_value).")
 
-                sql = f"EXEC {stored_procedure} {param_placeholders}"
-                cursor.execute(sql, tuple(param_values))
+                    sql = f"EXEC {stored_procedure} {param_placeholders}"
+                    rows_updated = cursor.execute(sql, tuple(param_values))
+                else:
+                    sql = f"EXEC {stored_procedure}"
+                    rows_updated = cursor.execute(sql)
+                    print("Should be executed")
                 conn.commit()
                 result["success"] = True
+                result["rows_updated"] = rows_updated.rowcount
     except pyodbc.Error as e:
         result["error_message"] = f"Database error: {str(e)}"
     except ValueError as e:


### PR DESCRIPTION
Stored procedure to run without params, first used in the purge database robot.
Return dict contains the number of rows affected (possibly only if actually returned by the stored procedure, otherwise might just be -1).
Docstrings are updated.