### PR TITLE
added tests to various GetOrganized elements

### DIFF
--- a/mbu_dev_shared_components/tests/go_tests/go_integration_tests.py
+++ b/mbu_dev_shared_components/tests/go_tests/go_integration_tests.py
@@ -1,0 +1,291 @@
+"""
+Integration tests that hit the GetOrganized API. Should run every morning?
+
+Required environment variables:
+    GO_API_ENDPOINT
+    GO_USERNAME
+    GO_PASSWORD
+
+    TEST_PERSON_FULL_NAME
+    TEST_PERSON_SSN
+    TEST_PERSON_GO_ID
+    TEST_PERSON_CITIZEN_CASE_ID
+"""
+
+import os
+import xml.etree.ElementTree as ET
+
+import requests
+
+import pytest
+
+from mbu_dev_shared_components.getorganized import contacts
+from mbu_dev_shared_components.getorganized import cases
+from mbu_dev_shared_components.getorganized import documents
+from mbu_dev_shared_components.getorganized import objects
+
+
+# --- Helper to load env vars safely ---
+def _get_cfg(key: str) -> str:
+    val = os.getenv(key)
+
+    if not val:
+        pytest.skip(f"env var '{key}' not set → skipping integration test")
+
+    return val
+
+
+# --- Load required config once ---
+GO_API_ENDPOINT = _get_cfg("GO_API_ENDPOINT")
+GO_USERNAME = _get_cfg("GO_API_USERNAME")
+GO_PASSWORD = _get_cfg("GO_API_PASSWORD")
+
+# Below values are tied to the dadj profile
+TEST_PERSON_FULL_NAME = _get_cfg("DADJ_FULL_NAME")
+TEST_PERSON_SSN = _get_cfg("DADJ_SSN")
+TEST_PERSON_GO_ID = _get_cfg("DADJ_GO_ID")
+TEST_PERSON_CITIZEN_CASE_ID = _get_cfg("DADJ_BORGERMAPPE_SAGS_ID")
+
+
+# ---------------------------------------------------------------------------
+# Authentication test
+# ---------------------------------------------------------------------------
+def test_authentication_success():
+    """Ensure valid credentials return authorized access (not 401/403)."""
+
+    resp = contacts.contact_lookup(
+        person_ssn=TEST_PERSON_SSN,
+        api_endpoint=f"{GO_API_ENDPOINT}/_goapi/contacts/readitem",
+        api_username=GO_USERNAME,
+        api_password=GO_PASSWORD,
+    )
+
+    assert resp.status_code != 401, "Unauthorized - check username/password"
+
+    assert resp.status_code != 403, "Forbidden - credentials lack permissions"
+
+    assert resp.ok, f"Unexpected failure - status={resp.status_code}"
+
+
+# ---------------------------------------------------------------------------
+# Contact lookup test
+# ---------------------------------------------------------------------------
+def test_contact_lookup_returns_expected_name():
+    """
+    Ensure contact_lookup returns JSON with expected fields and matches
+    the known test citizen.
+    """
+
+    resp = contacts.contact_lookup(
+        person_ssn=TEST_PERSON_SSN,
+        api_endpoint=f"{GO_API_ENDPOINT}/_goapi/contacts/readitem",
+        api_username=GO_USERNAME,
+        api_password=GO_PASSWORD,
+    )
+
+    assert resp.ok, f"Contact lookup failed, status={resp.status_code}"
+
+    data = resp.json()
+
+    assert data["FullName"] == TEST_PERSON_FULL_NAME
+
+    assert data["ID"] == TEST_PERSON_GO_ID
+
+    assert data["CPR"] == TEST_PERSON_SSN
+
+
+# ---------------------------------------------------------------------------
+# Cases testing
+# ---------------------------------------------------------------------------
+def test_case_metadata_structure():
+    """
+    Fetch metadata for a known case and check that returned 'Metadata' XML
+    parses and contains expected root attributes.
+    """
+
+    resp = cases.get_case_metadata(
+        api_endpoint=f"{GO_API_ENDPOINT}/_goapi/Cases/Metadata/{TEST_PERSON_CITIZEN_CASE_ID}",
+        api_username=GO_USERNAME,
+        api_password=GO_PASSWORD,
+    )
+
+    assert resp.ok, f"Metadata request failed, status={resp.status_code}"
+
+    resp_metadata_xml = resp.json().get("Metadata")
+
+    assert resp_metadata_xml, "No 'Metadata' field in response"
+
+    data = ET.fromstring(resp_metadata_xml).attrib
+
+    assert data["ows_CaseID"] == TEST_PERSON_CITIZEN_CASE_ID
+
+    assert data["ows_CaseCategory"] == "Borgermappe"
+
+    assert data["ows_CCMContactData"] == f"{TEST_PERSON_FULL_NAME};#{TEST_PERSON_GO_ID};#{TEST_PERSON_SSN};#;#"
+
+    assert data["ows_CCMContactData_CPR"] == TEST_PERSON_SSN
+
+
+def test_find_case_by_case_properties():
+    """
+    Test searching for a case by its properties using the find_case_by_case_properties function.
+    This should return a response with the expected case metadata.
+    """
+
+    case_data_json = objects.CaseDataJson()
+
+    case_data = case_data_json.search_citizen_folder_data_json(
+        case_type_prefix="BOR",
+        person_full_name=TEST_PERSON_FULL_NAME,
+        person_id=TEST_PERSON_GO_ID,
+        person_ssn=TEST_PERSON_SSN
+    )
+
+    resp = cases.find_case_by_case_properties(
+        case_data=case_data,
+        api_endpoint=f"{GO_API_ENDPOINT}/_goapi/Cases/FindByCaseProperties",
+        api_username=GO_USERNAME,
+        api_password=GO_PASSWORD,
+    )
+
+    assert resp.ok, f"Case search failed, status={resp.status_code}"
+
+    data = resp.json().get("CasesInfo")
+
+    assert isinstance(data, list), f"Expected a list of cases, actual returned type: {type(data)}"
+
+    assert len(data) == 1, f"Expected one case to be returned, actual returned cases: {len(data)}"
+
+    assert data[0].get("CaseID") == TEST_PERSON_CITIZEN_CASE_ID, f"Returned case ID does not match expected, actual returned case_id: {data[0].get('CaseID')}"
+
+
+# ---------------------------------------------------------------------------
+# Documents testing
+# ---------------------------------------------------------------------------
+def test_get_document_metadata():
+    """
+    Test fetching metadata for a document by its ID.
+    This should return a response with the expected document metadata.
+    """
+
+    document_id = 14583373  # This value is tied to dadj profile
+
+    resp = documents.get_document_metadata(
+        api_endpoint=f"{GO_API_ENDPOINT}/_goapi/Documents/Metadata/{document_id}",
+        api_username=GO_USERNAME,
+        api_password=GO_PASSWORD,
+    )
+
+    assert resp.ok, f"Document metadata request failed, status={resp.status_code}"
+
+    data = ET.fromstring(resp.json().get("Metadata")).attrib
+
+    assert "ows_Title" in data, "Metadata does not contain 'ows_Title'"
+
+
+def test_search_documents():
+    """
+    Test searching for documents by their properties.
+    This should return a response with the expected document metadata.
+    """
+
+    search_term = f"{TEST_PERSON_FULL_NAME} {TEST_PERSON_SSN}"
+
+    resp = documents.search_documents(
+        search_term=search_term,
+        api_endpoint=f"{GO_API_ENDPOINT}/_goapi/Search/Results",
+        api_username=GO_USERNAME,
+        api_password=GO_PASSWORD,
+    )
+
+    assert resp.ok, f"Document search failed, status={resp.status_code}"
+
+    results = resp.json().get("Rows").get("Results")
+
+    total_rows = resp.json().get("TotalRows")
+
+    assert isinstance(results, list), f"Expected a list of documents, actual returned type: {type(results)}"
+
+    if total_rows == 0:
+        assert len(results) == 0, "Expected no documents to be returned, but some were found"
+
+    else:
+        assert len(results) > 0, "Expected at least one document to be returned, but none were found"
+
+        assert len(results) == total_rows, f"Expected {total_rows} documents, but found {len(results)}"
+
+        for doc in results:
+            assert "title" in doc, "Document metadata does not contain 'title'"
+
+            assert "created" in doc, "Document metadata does not contain 'created'"
+
+            assert "caseid" in doc, "Document metadata does not contain 'caseid'"
+
+
+def _validate_modern_search_response(resp: requests.Response):
+    """
+    Shared logic to validate a modern search response.
+    """
+
+    assert resp.ok, f"Modern search failed, status={resp.status_code}"
+
+    json_data = resp.json()
+
+    results = json_data.get("results", {}).get("Results", [])
+
+    total_rows = json_data.get("totalRows")
+
+    assert isinstance(results, list), f"Expected list, got {type(results)}"
+
+    if total_rows == 0:
+        assert len(results) == 0, "Expected no results, but some were found"
+
+    else:
+        assert len(results) > 0, "Expected results, but none found"
+
+        assert len(results) == total_rows, f"Expected {total_rows}, got {len(results)}"
+
+        for doc in results:
+            assert "title" in doc, "Missing 'title' in result"
+
+            assert "created" in doc, "Missing 'created' in result"
+
+            assert "caseid" in doc, "Missing 'caseid' in result"
+
+
+def test_modern_search():
+    """
+    Test modern search with and without date range.
+    """
+
+    search_term = f"{TEST_PERSON_FULL_NAME} {TEST_PERSON_SSN}"
+
+    # 1: No date range
+    resp_1 = documents.modern_search(
+        page_index=0,
+        search_term=search_term,
+        start_date=None,
+        end_date=None,
+        only_items=False,
+        case_type_prefix="BOR",
+        api_endpoint=f"{GO_API_ENDPOINT}/_goapi/search/ExecuteModernSearch",
+        api_username=GO_USERNAME,
+        api_password=GO_PASSWORD,
+    )
+
+    # 2: With date range
+    resp_2 = documents.modern_search(
+        page_index=0,
+        search_term=search_term,
+        start_date="2025-03-01",
+        end_date="2025-03-31",
+        only_items=False,
+        case_type_prefix="BOR",
+        api_endpoint=f"{GO_API_ENDPOINT}/_goapi/search/ExecuteModernSearch",
+        api_username=GO_USERNAME,
+        api_password=GO_PASSWORD,
+    )
+
+    _validate_modern_search_response(resp_1)
+
+    _validate_modern_search_response(resp_2)

--- a/mbu_dev_shared_components/tests/go_tests/objects_tests.py
+++ b/mbu_dev_shared_components/tests/go_tests/objects_tests.py
@@ -1,0 +1,124 @@
+"""
+Unit tests for data structure creation methods in CaseDataJson.
+These are pure functions that return formatted dictionaries, used in API requests.
+
+Should run on pull requests to ensure the data structure is correct.
+"""
+
+import pytest
+from mbu_dev_shared_components.getorganized.objects import CaseDataJson
+
+
+@pytest.fixture
+def case_data_handler():
+    """
+    Fixture to provide an instance of CaseDataJson for testing.
+    """
+    return CaseDataJson()
+
+
+def test_search_citizen_folder_data_json(case_data_handler: CaseDataJson):
+    """
+    Ensure that the search_citizen_folder_data_json method correctly builds
+    a search structure for a citizen's full data and filters by 'Borgermappe' case category.
+    """
+
+    result = case_data_handler.search_citizen_folder_data_json(
+        case_type_prefix="BOR",
+        person_full_name="Test Person",
+        person_id="12345",
+        person_ssn="0101011234"
+    )
+
+    assert result["LogicalOperator"] == "AND"
+    assert result["ExcludeDeletedCases"] == "True"
+    assert result["ReturnCasesNumber"] == "1"
+
+    assert {
+        "InternalName": "ows_CCMContactData",
+        "Value": "Test Person;#12345;#0101011234;#;#",
+        "DataType": "Text",
+        "ComparisonType": "Equal",
+        "IsMultiValue": "False"
+    } in result["FieldProperties"]
+
+    assert {
+        "InternalName": "ows_CaseCategory",
+        "Value": "Borgermappe",
+        "DataType": "Text",
+        "ComparisonType": "Equal",
+        "IsMultiValue": "False"
+    } in result["FieldProperties"]
+
+
+def test_generic_search_case_data_json_with_name_and_extra_field(case_data_handler: CaseDataJson):
+    """
+    Ensure that generic_search_case_data_json assembles a correct structure when using:
+    - a custom case_type_prefix,
+    - a non-default number of return cases,
+    - full citizen data,
+    - and extra field properties.
+    """
+
+    field_properties = {
+        "ows_Titel": "Lønbilag"
+    }
+
+    result = case_data_handler.generic_search_case_data_json(
+        case_type_prefix="PER",
+        person_full_name="Test Person",
+        person_id="12345",
+        person_ssn="0101011234",
+        include_name=True,
+        returned_cases_number="5",
+        field_properties=field_properties
+    )
+
+    assert result["CaseTypePrefixes"] == ["PER"]
+
+    assert {
+        "InternalName": "ows_CCMContactData",
+        "Value": "Test Person;#12345;#0101011234;#;#",
+        "DataType": "Text",
+        "ComparisonType": "Equal",
+        "IsMultiValue": "False"
+    } in result["FieldProperties"]
+
+    assert result["ReturnCasesNumber"] == "5"
+
+    assert {
+        "InternalName": "ows_Titel",
+        "Value": "Lønbilag",
+        "DataType": "Text",
+        "ComparisonType": "Equal",
+        "IsMultiValue": "False"
+    } in result["FieldProperties"]
+
+
+def test_generic_search_case_data_json_without_name(case_data_handler: CaseDataJson):
+    """
+    Ensure that generic_search_case_data_json builds correct contact data when include_name=False,
+    and only includes one field (ows_CCMContactData) by default when no additional fields are passed.
+    """
+
+    result = case_data_handler.generic_search_case_data_json(
+        case_type_prefix="BOR",
+        person_full_name="Daniel Tester",
+        person_id="12345",
+        person_ssn="0101011234",
+        include_name=False
+    )
+
+    assert result["CaseTypePrefixes"] == ["BOR"]
+
+    assert {
+        "InternalName": "ows_CCMContactData",
+        "Value": ";#12345;#0101011234;#;#",
+        "DataType": "Text",
+        "ComparisonType": "Equal",
+        "IsMultiValue": "False"
+    } in result["FieldProperties"]
+
+    assert result["ReturnCasesNumber"] == "1"
+
+    assert len(result["FieldProperties"]) == 1

--- a/mbu_dev_shared_components/tests/go_tests/test.py
+++ b/mbu_dev_shared_components/tests/go_tests/test.py
@@ -1,0 +1,60 @@
+"""
+Integration tests that hit the GetOrganized API.
+
+Required environment variables:
+    GO_API_ENDPOINT
+    GO_USERNAME
+    GO_PASSWORD
+
+    TEST_PERSON_FULL_NAME
+    TEST_PERSON_SSN
+    TEST_PERSON_GO_ID
+    TEST_PERSON_CITIZEN_CASE_ID
+"""
+
+import os
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from mbu_dev_shared_components.getorganized import contacts
+from mbu_dev_shared_components.getorganized import cases
+from mbu_dev_shared_components.getorganized import documents
+from mbu_dev_shared_components.getorganized import objects
+
+
+# --- Helper to load env vars safely ---
+def _get_cfg(key: str) -> str:
+    val = os.getenv(key)
+
+    if not val:
+        pytest.skip(f"env var '{key}' not set → skipping integration test")
+
+    return val
+
+
+# --- Load required config once ---
+GO_API_ENDPOINT = _get_cfg("GO_API_ENDPOINT")
+GO_USERNAME = _get_cfg("GO_API_USERNAME")
+GO_PASSWORD = _get_cfg("GO_API_PASSWORD")
+
+TEST_PERSON_FULL_NAME = _get_cfg("DADJ_FULL_NAME")
+TEST_PERSON_SSN = _get_cfg("DADJ_SSN")
+TEST_PERSON_GO_ID = _get_cfg("DADJ_GO_ID")
+TEST_PERSON_CITIZEN_CASE_ID = _get_cfg("DADJ_BORGERMAPPE_SAGS_ID")
+
+
+# ---------------------------------------------------------------------------
+# tests
+# ---------------------------------------------------------------------------
+document_id = 14583373  # This value is tied to dadj profile
+
+case_metadata_response = documents.get_document_metadata(
+    api_endpoint=f"{GO_API_ENDPOINT}/_goapi/Documents/Metadata/{document_id}",
+    api_username=GO_USERNAME,
+    api_password=GO_PASSWORD,
+)
+
+parsed_metadata = ET.fromstring(case_metadata_response.json().get("Metadata")).attrib
+
+print(f"Document Metadata: {parsed_metadata}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,8 @@ dependencies = [
   "docx2pdf",
   "rawpy",
 ]
+
+[project.optional-dependencies]
+dev = [
+  "pytest >= 7.0",
+]


### PR DESCRIPTION
Added both api integration tests and json object tests for the purpose of testing the GO API.
The idea is that each morning, the api integration tests run, to ensure that our user is still valid and authorized, as well as ensuring that the api responses still behave how we expect them to.

The json object tests would run on each pull request to ensure that we haven't messed with their outputs, as they are crucial for how we later interact with the GO API