### PR TITLE
feat: implement _set_department_journals combobox selection

### DIFF
--- a/mbu_dev_shared_components/solteqtand/application/journal_note.py
+++ b/mbu_dev_shared_components/solteqtand/application/journal_note.py
@@ -12,7 +12,43 @@ class JournalNoteHandler(HandlerBase):
     Handles the processing of journal notes in the Solteq Tand application.
     """
 
-    def create_journal_note(self, note_message: str, checkmark_in_complete: bool):
+    def _set_department_journals(
+        self, department: str = "Generel Journal - Påbegyndt"
+    ) -> None:
+        """
+        Sets the department journal combobox to the given value.
+
+        Args:
+            department (str): The department journal to select. Matches on startswith,
+                so partial values like "Generel Journal - Påbegyndt" will match
+                "Generel Journal - Påbegyndt - 11-11-2024" etc.
+                Defaults to "Generel Journal - Påbegyndt".
+
+        Raises:
+            ValueError: If no department journal is found starting with the given value.
+        """
+
+        combobox = self.app_window.ComboBoxControl(AutomationId="cmbDepartmentJournals")
+        combobox.SetFocus()
+
+        # Expand the combobox to load all options
+        expand_pattern = combobox.GetExpandCollapsePattern()
+        expand_pattern.Expand()
+
+        # Find the item that starts with the department string
+        for item in combobox.GetChildren():
+            if item.Name.startswith(department):
+                item.Click(simulateMove=False, waitTime=0)
+                return
+
+        raise ValueError(f"No department journal found starting with: '{department}'")
+
+    def create_journal_note(
+        self,
+        note_message: str,
+        checkmark_in_complete: bool,
+        department: str,
+    ):
         """
         Creates a journal note for the given patient.
 
@@ -21,6 +57,8 @@ class JournalNoteHandler(HandlerBase):
             checkmark_in_complete (bool): Checks the checkmark in 'Afslut'.
         """
         self.open_tab("Journal")
+
+        self._set_department_journals(department=department)
 
         self.wait_for_control(
             auto.DocumentControl, {"AutomationId": "RichTextBoxInput"}, search_depth=21

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mbu_dev_shared_components"
-version = "4.4.6"
+version = "4.4.7"
 authors = [
   { name="MBU", email="rpa@mbu.aarhus.dk" },
 ]


### PR DESCRIPTION
## What
Implements the previously empty `_set_department_journals` method, which sets the department journal combobox to a given value.

## Why
The method was a stub, causing journal notes to be created without the correct department journal selected.

## How
- Locates the combobox by `AutomationId="cmbDepartmentJournals"`
- Expands the combobox and matches items using `startswith` to support dynamic suffixes
- Raises `ValueError` if no matching item is found